### PR TITLE
Changed hard path to user directory to home variable

### DIFF
--- a/src/runI.sh
+++ b/src/runI.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-javac --module-path /Users/davidspiegel/Downloads/Important_Insta/javafx-sdk-17.0.1/lib --add-modules javafx.controls,javafx.fxml view/IplanetFX.java
+javac --module-path $HOME/Downloads/Important_Insta/javafx-sdk-17.0.1/lib --add-modules javafx.controls,javafx.fxml view/IplanetFX.java
 
-java --module-path /Users/davidspiegel/Downloads/Important_Insta/javafx-sdk-17.0.1/lib --add-modules javafx.controls,javafx.fxml view.IplanetFX
+java --module-path $HOME/Downloads/Important_Insta/javafx-sdk-17.0.1/lib --add-modules javafx.controls,javafx.fxml view.IplanetFX


### PR DESCRIPTION
This just make it work better on other systems. $HOME is a variable that exists in bash that contains the path to the users home directory. Before accepting, open your terminal and run 'echo $HOME'. It should output the path to your home directory. If it doesn't output anything just delete this request because it will break your run script